### PR TITLE
Update provider pinning to support 3.0 and beyond

### DIFF
--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = ">= 3.0, != 3.14.0"
     }
   }
 }


### PR DESCRIPTION
When we discover issues we can black list specific version in the future. 